### PR TITLE
update bash_profile for newer mac

### DIFF
--- a/bash_profile/path.sh
+++ b/bash_profile/path.sh
@@ -4,16 +4,20 @@
 #               superfluous variables
 # [usage] copy this whole things into your `~/.bash_profile`
 build_path() {
-	
-	local SUBLIME="/Applications/Sublime Text.app/Contents/SharedSupport/bin"
-	local MINICONDA="/Users/${USER}/miniconda3/bin"
-	
-	# Putting this on the path "because of reasons". RStudio bundles a pandoc
-	# version with its distribution and some R packages only work if you
-	# find RStudio's version. Ugh.
-	local RSTUDIO_PANDOC="/Applications/Rstudio.app/Contents/MacOS/pandoc"
 
-	# Create the final path
-	export PATH="${SUBLIME}:${MINICONDA}:${RSTUDIO_PANDOC}:$PATH"
+    local SUBLIME="/Applications/Sublime Text.app/Contents/SharedSupport/bin"
+    local MINICONDA="/Users/${USER}/miniconda3/bin"
+
+    # Putting this on the path "because of reasons". RStudio bundles a pandoc
+    # version with its distribution and some R packages only work if you
+    # find RStudio's version. Ugh.
+    local RSTUDIO_PANDOC="/Applications/Rstudio.app/Contents/MacOS/pandoc"
+
+    # Homebrew
+    # warning: Homebrew's "sbin" was not found in your PATH but you have installed
+    # formulae that put executables in /usr/local/sbin.
+    local BREW_SBIN="/usr/local/sbin"
+
+    export PATH="${SUBLIME}:${MINICONDA}:${RSTUDIO_PANDOC}:${BREW_SBIN}:$PATH"
 }
 build_path

--- a/bash_profile/prompt.sh
+++ b/bash_profile/prompt.sh
@@ -3,3 +3,6 @@ export PS1="😬 ./\W \$ "
 
 # only show a few directories at prompt
 export PROMPT_DIRTRIM=2
+
+# silence warning about zsh being the default shell on newer Macs
+export BASH_SILENCE_DEPRECATION_WARNING=1


### PR DESCRIPTION
Proposes some miscellaneous small updates to `.bash_profile`  bits, to work with newer Macs.

* puts Homebrew's `sbin/` on `PATH`
* suppresses warning in terminal about `zsh` being the new default shell on Mac