### PR TITLE
modify gp()

### DIFF
--- a/bash_profile/git.sh
+++ b/bash_profile/git.sh
@@ -78,14 +78,18 @@ fetch_pr (){
 }
 
 # [description] Push current branch to remote without
-#               needing to type out the name
+#               needing to type out the branch name.
 # [usage]
-# 
-#      gp
+#     # push to 'origin'
+#     gp
+#
+#     # push to some other remote
+#     gp upstream
 #
 # [requires] git
 gp (){
-    git push origin HEAD
+    local remote=${1:-origin}
+    git push ${remote} HEAD
 }
 
 # [description] Remove all files in a repo that are explicitly


### PR DESCRIPTION
When I work on open source stuff on GitHub, I usually us `origin` as the remote for my fork and `upstream` for the main remote project.

For example,

```shell
cd ./LightGBM
git remote -v
```

```text
origin	git@github.com:jameslamb/LightGBM.git (fetch)
origin	git@github.com:jameslamb/LightGBM.git (push)
upstream	git@github.com:microsoft/LightGBM.git (fetch)
upstream	git@github.com:microsoft/LightGBM.git (push
```

This PR modifies `gp()` that I keep around in my `.bash_profile`, to allow optionally targeting a different remote.